### PR TITLE
Add `inuit-input-use-width-instead-of-max-width` flag

### DIFF
--- a/_base.forms.scss
+++ b/_base.forms.scss
@@ -193,6 +193,11 @@ $inuit-forms-validation-success-background  : var(--px-validation-success-backgr
 /// @todo N/A
 $inuit-letter-spacing--caps                 : var(--px-headings-letter-spacing, 0.3px) !default;
 
+/// Use `width` instead of `max-width`?
+/// @group px-forms-design:variables:style
+/// @type Boolean [default]
+$inuit-input-use-width-instead-of-max-width : false !default;
+
 /// Generate the CSS for one line form fields?
 /// @group px-forms-design:variables:flag
 /// @type Boolean [default]
@@ -476,7 +481,11 @@ select::-ms-expand {
 
   .#{$inuit-forms-namespace}input--tiny,
   %#{$inuit-forms-namespace}input--tiny {
-    max-width: calculateRem(106px);
+    @if ($inuit-input-use-width-instead-of-max-width == true) {
+      width: calculateRem(106px);
+    } @else {
+      max-width: calculateRem(106px);
+    }
   }
 
 }
@@ -485,7 +494,11 @@ select::-ms-expand {
 
   .#{$inuit-forms-namespace}input--small,
   %#{$inuit-forms-namespace}input--small {
-    max-width: calculateRem(212px);
+    @if ($inuit-input-use-width-instead-of-max-width == true) {
+      width: calculateRem(212px);
+    } @else {
+      max-width: calculateRem(212px);
+    }
   }
 
 }
@@ -494,7 +507,11 @@ select::-ms-expand {
 
   .#{$inuit-forms-namespace}input--regular,
   %#{$inuit-forms-namespace}input--regular {
-    max-width: calculateRem(318px);
+    @if ($inuit-input-use-width-instead-of-max-width == true) {
+      width: calculateRem(318px);
+    } @else {
+      max-width: calculateRem(318px);
+    }
   }
 
 }
@@ -503,7 +520,11 @@ select::-ms-expand {
 
   .#{$inuit-forms-namespace}input--large,
   %#{$inuit-forms-namespace}input--large {
-    max-width: calculateRem(424px);
+    @if ($inuit-input-use-width-instead-of-max-width == true) {
+      width: calculateRem(424px);
+    } @else {
+      max-width: calculateRem(424px);
+    }
   }
 
 }
@@ -512,7 +533,11 @@ select::-ms-expand {
 
   .#{$inuit-forms-namespace}input--huge,
   %#{$inuit-forms-namespace}input--huge {
-    max-width: calculateRem(530px);
+    @if ($inuit-input-use-width-instead-of-max-width == true) {
+      width: calculateRem(530px);
+    } @else {
+      max-width: calculateRem(530px);
+    }
   }
 
 }


### PR DESCRIPTION
## A description of the changes proposed in the pull request:

This pull adds a simple flag to use `width` instead of `max-width` for the input length of forms.

### Why `$inuit-input-use-width-instead-of-max-width`?

I want to put `<input class="text-input input--small">` inside a flexbox.

The issue with this (as far as I know) is that the `input--${size}` classes use `max-width` and `max-width` will always collapse to the minimum when paired with any `flex: 1` element.

Since I'm a flexbox addict, I'd like to propose this flag that changes the `max-width` to `width` for inputs.

This simple flag doesn't change the current API and may solve this problem for other people if they opt-in to it.

Thank you!

## working tests:

I don't have tests but I do have screenshots of my inspector:

### Tiny with flag

![image](https://user-images.githubusercontent.com/10551026/31372685-fb46c8c2-ad64-11e7-9c09-61ef4009c6de.png)

### Small with flag

![image](https://user-images.githubusercontent.com/10551026/31372709-18ce4294-ad65-11e7-98b6-93f4bfe2b897.png)

### Regular with flag

![image](https://user-images.githubusercontent.com/10551026/31372736-331df40a-ad65-11e7-964f-c673992e399f.png)

### Large with flag

![image](https://user-images.githubusercontent.com/10551026/31372753-48494726-ad65-11e7-96b9-62f5bbfb3319.png)

### Huge with flag

![image](https://user-images.githubusercontent.com/10551026/31372775-5db22236-ad65-11e7-9985-fc15d850a8c7.png)

And similarly, disabling or not including the flags results the normal stuff.

### Tiny *without* flag

![image](https://user-images.githubusercontent.com/10551026/31372818-934057c4-ad65-11e7-804b-81c760f64ae1.png)

### Small *without* flag

![image](https://user-images.githubusercontent.com/10551026/31372838-a7983d40-ad65-11e7-8fba-649844a7453b.png)

etc...